### PR TITLE
install xpcshell by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,38 @@
 PORT_DEVICE = localfilesystem:/data/local/debugger-socket
 PORT_LOCAL = 6000
-XPCSHELL = ~/bin/xulrunner-sdk/bin/xpcshell
+XPCSHELL = ./xulrunner-sdk/bin/xpcshell
 ADB = ~/bin/android-sdk/platform-tools/adb
 ID ?= ${shell basename ${FOLDER} | tr A-Z a-z}
+PLATFORM = linux-x86_64
+XULRUNNER_VERSION = 18.0.2
+XULRUNNER_URL = https://ftp.mozilla.org/pub/xulrunner/releases/${XULRUNNER_VERSION}/sdk/xulrunner-${XULRUNNER_VERSION}.en-US.${PLATFORM}.sdk.tar.bz2
 
-package:
-	@echo "ZIPPING ${FOLDER} into application.zip"
-	@cd ${FOLDER} && zip -Xr ./application.zip ./* -x application.zip *.appcache
+.PHONY: _default
+_default: packaged install
 
-packaged: package
-	@echo "PUSHING *${ID}* as packaged app"
-	@${ADB} push ${FOLDER}/application.zip /data/local/tmp/b2g/${ID}/application.zip
+xulrunner-sdk/bin/xpcshell:
+	$(info Downloading xulrunner...)
+	curl -o /tmp/xulrunner.tar.bz2 "${XULRUNNER_URL}"
+	$(info Extracting xulrunner...)
+	tar -xvf /tmp/xulrunner.tar.bz2
 
+${FOLDER}/application.zip:
+	$(info "ZIPPING ${FOLDER} into application.zip")
+	cd ${FOLDER} && zip -Xr ./application.zip ./* -x application.zip *.appcache
+
+.PHONY: packaged
+packaged: ${FOLDER}/application.zip
+	$(info "PUSHING *${ID}* as packaged app")
+	${ADB} push ${FOLDER}/application.zip /data/local/tmp/b2g/${ID}/application.zip
+
+.PHONY: hosted
 hosted:
-	@echo "PUSHING *${ID}* as hosted app"
-	@${ADB} push ${FOLDER}/manifest.webapp /data/local/tmp/b2g/${ID}/manifest.webapp
-	@${ADB} push ${FOLDER}/metadata.json /data/local/tmp/b2g/${ID}/metadata.json
+	$(info "PUSHING *${ID}* as hosted app")
+	${ADB} push ${FOLDER}/manifest.webapp /data/local/tmp/b2g/${ID}/manifest.webapp
+	${ADB} push ${FOLDER}/metadata.json /data/local/tmp/b2g/${ID}/metadata.json
 
-install:
-	@echo "FORWARDING device port $(PORT_DEVICE) to $(PORT_LOCAL)"
-	@${ADB} forward tcp:$(PORT_LOCAL) $(PORT_DEVICE)
-	${XPCSHELL} install.js ${ID} $(PORT_LOCAL)
+.PHONY: install
+install: xulrunner-sdk/bin/xpcshell
+	$(info "FORWARDING device port ${PORT_DEVICE} to ${PORT_LOCAL}")
+	${ADB} forward tcp:${PORT_LOCAL} ${PORT_DEVICE}
+	LD_LIBRARY_PATH=${shell pwd}/xulrunner-sdk/bin ${XPCSHELL} install.js ${ID} ${PORT_LOCAL}


### PR DESCRIPTION
Had some trouble installing xpcshell manually; I eventually got it working using LD_LIBRARY_PATH. I thought it might be nice to do this automatically.